### PR TITLE
MTN bump python version and use ruff

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -16,12 +16,12 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            version_python: 3.7
+            version_python: 3.9
             coverage: 'true'
           - os: ubuntu-latest
-            version_python: 3.8
+            version_python: "3.10"
           - os: macos-latest
-            version_python: 3.8
+            version_python: "3.10"
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
@@ -32,9 +32,20 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install -e .[test]
-    - name: Lint with flake8
-      run: |
-        flake8 linear_regression
     - name: Test with pytest
       run: |
         pytest
+  unittest:
+    name: Linting
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.10"
+    - name: Install Ruff
+      run: python -m pip install ruff
+    - name: Lint with flake8
+      run: |
+        ruff check .

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Test with pytest
       run: |
         pytest
-  unittest:
+  lint:
     name: Linting
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -4,13 +4,16 @@
 
 Doc, install and writing code
 -----------------------------
-- Create a new github repository, check all marks ! gitignore, license and readme. 
+- Create a new github repository, check all marks:
+  - [ ] gitignore,
+  - [ ] license,
+  - [ ] README.
 - Clone the repository on your computer
-- Write a doc for the function
-- Organize code as a package : `folder/code/functions.py`, and add an `__init__.py` file, in which only the version is present.
-- At the root, write a pyproject.toml function that will allow to install the package, and then do `pip install -e.`. This should not return any error.
-- In the code folder, create a `tests` folder, a `test_linear_regression.py` file in it and write several test functions, with names starting with `test_`. Then, run `pytest` at the root file. All tests should pass
-- Check that the code is compatible with pep 8 using the command `flake8`
+- Write docstring for the function
+- *Organize code as a package:* `folder/code/functions.py`, and add an `__init__.py` file, in which only the version is present.
+- At the root, write a `pyproject.toml` function that will allow to install the package, and then do `pip install -e.`. This should not return errors.
+- In the code folder, create a `tests` folder, a `test_linear_regression.py` file in it and write several test functions, with names starting with `test_`. Then, run `pytest` at the root file. All tests should pass.
+- Check that the code is compatible with pep 8 using the command `ruff`, this can be installed using `pip install ruff`.
 - Upload everything on github by first adding all new files using `git add ...`, then commiting by using `git commit -am ` (write a message here) and then `git push`. Check on github that the new code is here.
 
 Documentation 
@@ -18,8 +21,22 @@ Documentation
 - At the root, create an `examples` folder. In this folder, create a function `plot_simple_example` in which you write a small example of what the linear regression code can do.
 - Add some plots using matplotlib. 
 
+## Deploying the website
+
+- Create an empty branch `gh-pages` on you repo
+```bash
+git stash
+git checkout --orphan gh-pages
+git reset --hard
+git commit --allow-empty -m "INIT gh-pages branch"
+git push -u origin gh-pages
+git checkout main
+git stash pop
+```
+- In the settings, activate the the doc rendering options.
+
 ## Continuous integration
-- Add a `.github/workflows` folder at the root, and write a `unittests.yml` file in it that runs continuous integration on github. This should run the `flake8` and unit tests command, everytime there is a push on the main github branch, or that somebody does a pull request
+- Add a `.github/workflows` folder at the root, and write a `unittests.yml` file in it that runs continuous integration on github. This should run the `ruff` and unit tests command, everytime there is a push on the main github branch, or that somebody does a pull request
 
 ## Pull requests
 - By pair, fork the github repository of one of the other student, create a new branch using `git checkout -b branch-name`, then implement regularized linear regression in the `linear_regression/linear_regression.py` file. Then, commit your changes, push the branch on github, and do a pull request on the other students' repo. 


### PR DESCRIPTION
- Bump up python version in CI
- Use ruff instead of `flake8`
- Add instruction on how to create the `gh-pages` branch.